### PR TITLE
traP Collectionのurl修正

### DIFF
--- a/src/urls.js
+++ b/src/urls.js
@@ -35,8 +35,12 @@ export default [
     url: github('traPortfolio', 'docs/swagger/traPortfolio.v1.yaml', 'main')
   },
   {
-    name: 'traP Collection',
-    url: github('trap-collection-server', 'docs/swagger/openapi.yml', 'develop')
+    name: 'traP Collection v1 API',
+    url: github('trap-collection-server', 'docs/openapi/v1.yaml', 'main')
+  },
+  {
+    name: 'traP Collection v2 API',
+    url: github('trap-collection-server', 'docs/openapi/v2.yaml', 'main')
   },
   {
     name: 'NeoShowcase',


### PR DESCRIPTION
https://github.com/traPtitech/trap-collection-server/pull/406 で追加されたv2のAPIと、
https://github.com/traPtitech/trap-collection-server/pull/412 でのパス変更の反映です。
https://github.com/traPtitech/trap-collection-server/pull/412 のマージ後にマージ予定。
一応確認お願いします:pray: